### PR TITLE
Update AutomatedSetupWithIMC.txt

### DIFF
--- a/doc/AutomatedSetupWithIMC.txt
+++ b/doc/AutomatedSetupWithIMC.txt
@@ -37,8 +37,10 @@ as path delimiter, installation paths etc.
    directory as the files in the previous steps.
 
      mkdir "C:\Program Files\iTALC"
-     cp *.exe *.dll *.txt *.xml "C:\Program Files\iTALC\"
-     cd "\Program Files\iTALC"
+     copy "%~dp0\*.exe" "C:\Program Files\iTALC"
+     copy "%~dp0\*.dll" "C:\Program Files\iTALC"
+     copy "%~dp0\*.txt" "C:\Program Files\iTALC"
+     copy "%~dp0\*.xml" "C:\Program Files\iTALC"
      imc -ApplySettings ClientSettings.xml
      imc -ImportPublicKey PublicKey.key.txt
      ica -RegisterService


### PR DESCRIPTION
Updated Batch-Script for Windows purposes.

"cp" is copy in Windows.
"%~dp0" expands to the path the batch file is lying in. Therefore Right-Clicking and "Run as Administrator" works from the explorer.
