### PR TITLE
discard output from slaves when not in debug mode

### DIFF
--- a/lib/src/Ipc/QtSlaveLauncher.cpp
+++ b/lib/src/Ipc/QtSlaveLauncher.cpp
@@ -36,6 +36,9 @@
 
 #ifdef ITALC_BUILD_WIN32
 #include <windows.h>
+#define DEV_NULL "NUL"
+#else
+#define DEV_NULL "/dev/null"
 #endif
 
 namespace Ipc
@@ -64,10 +67,16 @@ void QtSlaveLauncher::start( const QStringList &arguments )
 	m_processMutex.lock();
 	m_process = new QProcess;
 
-	// forward stdout from slave to master when in debug mode
 	if( ItalcCore::config->logLevel() >= Logger::LogLevelDebug )
 	{
+		// forward stdout from slave to master when in debug mode
 		m_process->setProcessChannelMode( QProcess::ForwardedChannels );
+	}
+	else
+	{
+		// discard output when not in debug mode
+		m_process->setStandardOutputFile( DEV_NULL );
+		m_process->setStandardErrorFile( DEV_NULL );
 	}
 
 #ifndef DEBUG


### PR DESCRIPTION
The demo slave generates some output via rfbLog. If no one reads the output channel, eventually the buffer fills and write() blocks, causing the demo server to hang. This fixes that by sending slave output to /dev/null when not forwarding it.

Reproduced on Ubuntu 12.04 and 14.04 by starting and stopping a demo repeatedly, or by starting a demo on many clients at the same time. After accepting about 13 connections, subsequent demo clients hang at "Establishing Connection", and `gdb` shows that the demo server is stuck in `rfbDefaultLog()`.

I have only tested this on Ubuntu, not on Windows. Note Qt 5.2 introduces `QProcess::nullDevice()`, however I avoided that in order to keep building with Qt 4.