### PR TITLE
Fix nullpointer exception in FillRectangle() if missing framebuffer

### DIFF
--- a/ica/x11/libvncclient/rfbproto.c
+++ b/ica/x11/libvncclient/rfbproto.c
@@ -143,6 +143,10 @@ void* rfbClientGetClientData(rfbClient* client, void* tag)
 static void FillRectangle(rfbClient* client, int x, int y, int w, int h, uint32_t colour) {
   int i,j;
 
+  if (client->frameBuffer == NULL) {
+      return;
+  }
+
 #define FILL_RECT(BPP) \
     for(j=y*client->width;j<(y+h)*client->width;j+=client->width) \
       for(i=x;i<x+w;i++) \
@@ -185,6 +189,10 @@ static void CopyRectangle(rfbClient* client, uint8_t* buffer, int x, int y, int 
 /* TODO: test */
 static void CopyRectangleFromRectangle(rfbClient* client, int src_x, int src_y, int w, int h, int dest_x, int dest_y) {
   int i,j;
+
+  if (client->frameBuffer == NULL) {
+      return;
+  }
 
 #define COPY_RECT_FROM_RECT(BPP) \
   { \


### PR DESCRIPTION
> (gdb) bt
> #0  FillRectangle (client=0x32dca00, x=229, y=<optimized out>, w=<optimized out>, h=<optimized out>, colour=14467239) at /var/build/temp/tmp.waiC6Hcw5s/pbuilder/italc-2.0.22/ica/x11/libvncclient/rfbproto.c:151
> #1  0x00007f058a33a305 in HandleTight32 (client=client@entry=0x32dca00, rx=229, ry=567, rw=309, rh=33) at /var/build/temp/tmp.waiC6Hcw5s/pbuilder/italc-2.0.22/ica/x11/libvncclient/tight.c:134
> #2  0x00007f058a36bc35 in HandleRFBServerMessage (client=0x32dca00) at /var/build/temp/tmp.waiC6Hcw5s/pbuilder/italc-2.0.22/ica/x11/libvncclient/rfbproto.c:2105
> #3  0x00007f058a33f6d2 in ItalcVncConnection::doConnection (this=this@entry=0x2b523c0) at /var/build/temp/tmp.waiC6Hcw5s/pbuilder/italc-2.0.22/lib/src/ItalcVncConnection.cpp:644
> #4  0x00007f058a33f7f8 in ItalcVncConnection::run (this=0x2b523c0) at /var/build/temp/tmp.waiC6Hcw5s/pbuilder/italc-2.0.22/lib/src/ItalcVncConnection.cpp:524
> #5  0x00007f05a9a57d0b in ?? () from /usr/lib/x86_64-linux-gnu/libQtCore.so.4
> #6  0x00007f05aca74b50 in start_thread (arg=<optimized out>) at pthread_create.c:304
> #7  0x00007f05abf1d70d in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:112
> #8  0x0000000000000000 in ?? ()
> (gdb) up
> #1  0x00007f058a33a305 in HandleTight32 (client=client@entry=0x32dca00, rx=229, ry=567, rw=309, rh=33) at /var/build/temp/tmp.waiC6Hcw5s/pbuilder/italc-2.0.22/ica/x11/libvncclient/tight.c:134
> 134	    FillRectangle(client, rx, ry, rw, rh, fill_colour);
> (gdb) print client->frameBuffer
> $1 = (uint8_t *) 0x0

Also adjusted CopyRectangleFromRectangle() - which is unused but just in case.
See also: https://github.com/iTALC/italc/commit/50ef01e29db08d6d2b5dcf77cfae8f4309f25ba8