### PR TITLE
Modified Windows installer to include platforms folder 

### DIFF
--- a/iTALC.nsi.in
+++ b/iTALC.nsi.in
@@ -66,12 +66,6 @@ ShowInstDetails show
 
 !insertmacro MUI_PAGE_COMPONENTS
 
-!if ${PROCESSOR}=="x86_64"
-!echo "conseguido"
-!define DLL_GCC "libgcc_s_seh-1.dll"
-!endif
-
-
 !ifdef REG_START_MENU
 !define MUI_STARTMENUPAGE_NODISABLE
 !define MUI_STARTMENUPAGE_DEFAULTFOLDER "iTALC"

--- a/iTALC.nsi.in
+++ b/iTALC.nsi.in
@@ -1,6 +1,12 @@
 !define DLLDIR "@MINGW_PREFIX@/bin"
 !define DLLDIR_LIB "@MINGW_PREFIX@/lib"
 !define DLLDIR_GCC "/usr/lib/gcc/@CMAKE_SYSTEM_PROCESSOR@-w64-mingw32/5.3-win32"
+!if "@CMAKE_SYSTEM_PROCESSOR@" == "x86_64"
+   !define DLL_GCC "libgcc_s_seh-1.dll"
+!else
+   !define DLL_GCC "libgcc_s_sjlj-1.dll"
+!endif
+!define QT5_PLUGINS_PLATFORMS "/usr/@CMAKE_SYSTEM_PROCESSOR@-w64-mingw32/lib/qt5/plugins/platforms"
 !define APP_NAME "iTALC"
 !define COMP_NAME "iTALC Solutions Inc."
 !define WEB_SITE "http://italc.sf.net"
@@ -59,6 +65,12 @@ ShowInstDetails show
 !insertmacro MUI_PAGE_DIRECTORY
 
 !insertmacro MUI_PAGE_COMPONENTS
+
+!if ${PROCESSOR}=="x86_64"
+!echo "conseguido"
+!define DLL_GCC "libgcc_s_seh-1.dll"
+!endif
+
 
 !ifdef REG_START_MENU
 !define MUI_STARTMENUPAGE_NODISABLE
@@ -162,7 +174,7 @@ File "${DLLDIR}\libpng16-16.dll"
 File "${DLLDIR_LIB}\zlib1.dll"
 File "${DLLDIR_LIB}\libwinpthread-1.dll"
 File "${DLLDIR_GCC}\libstdc++-6.dll"
-File "${DLLDIR_GCC}\libgcc_s_sjlj-1.dll"
+File "${DLLDIR_GCC}\${DLL_GCC}"
 # core components
 File "italc-${VERSION}\ica.exe"
 File "italc-${VERSION}\vnchooks.dll"
@@ -171,6 +183,9 @@ File "italc-${VERSION}\ItalcCore.dll"
 File "italc-${VERSION}\imc.exe"
 File "italc-${VERSION}\LICENSE.TXT"
 File "italc-${VERSION}\README.TXT"
+SetOutPath "$INSTDIR\platforms"
+File "${QT5_PLUGINS_PLATFORMS}/qwindows.dll"
+File "${QT5_PLUGINS_PLATFORMS}/qminimal.dll"
 SetOutPath "$INSTDIR\doc"
 File "italc-${VERSION}\doc\*txt"
 SetOutPath "$INSTDIR\contrib"
@@ -252,6 +267,7 @@ Sleep 2000
 Delete "$INSTDIR\ica.exe"
 Delete "$INSTDIR\libwinpthread-1.dll"
 Delete "$INSTDIR\libgcc_s_sjlj-1.dll"
+Delete "$INSTDIR\libgcc_s_seh-1.dll"
 Delete "$INSTDIR\libstdc++-6.dll"
 Delete "$INSTDIR\zlib1.dll"
 Delete "$INSTDIR\libjpeg-9.dll"
@@ -272,6 +288,7 @@ Delete "$INSTDIR\Qt5Gui.dll"
 Delete "$INSTDIR\Qt5Widgets.dll"
 Delete "$INSTDIR\uninstall.exe"
 Delete "$INSTDIR\iTALC website.url"
+RmDir /r "$INSTDIR\platforms"
 RmDir /r "$INSTDIR\doc"
 RmDir /r "$INSTDIR\contrib"
 


### PR DESCRIPTION
The Windows Installer generated by "make win-nsi" (cross-compiling) doesn't work. 
The "platforms" folder with "qwindows.dll" and "qminimal.dll" is missing.
This pull request solve this. 
It also includes the files:
- libgcc_s_sjlj-1.dll  (for win32) -- Included previously --
- libgcc_s_seh-1.dll (for win64) -- No included previously --