### PR TITLE
update lib/dialogs/AboutDialog.ui to Copyright © 2004-2016 ...

### DIFF
--- a/lib/dialogs/AboutDialog.ui
+++ b/lib/dialogs/AboutDialog.ui
@@ -102,7 +102,7 @@
          <property name="text">
           <string>iTALC - Intelligent Teaching And Learning with Computers
 
-Copyright © 2004-2013 Tobias Doerffel / iTALC Solutions</string>
+Copyright © 2004-2016 Tobias Doerffel / iTALC Solutions</string>
          </property>
         </widget>
        </item>


### PR DESCRIPTION
Another proposal. If you like ... yo can merge.

![aboutdialog ui](https://cloud.githubusercontent.com/assets/2934084/15305390/17d0ac04-1bc3-11e6-8b59-ba8af396742e.png)
