### PR TITLE
Italc3: some tunnings 

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -30,7 +30,7 @@ Requirements:
 - libssl-dev/openssl-devel
 - libpam0g-dev/pam-devel
 
-Of course GCC/G++ and cmake must not be missing...
+Of course GCC/G++, make and cmake must not be missing...
 
 
 Building:

--- a/INSTALL
+++ b/INSTALL
@@ -30,7 +30,7 @@ Requirements:
 - libssl-dev/openssl-devel
 - libpam0g-dev/pam-devel
 
-Of course GCC/G++ must not be missing...
+Of course GCC/G++ and cmake must not be missing...
 
 
 Building:

--- a/lib/src/ItalcCore.cpp
+++ b/lib/src/ItalcCore.cpp
@@ -137,7 +137,10 @@ void ItalcCore::setupApplicationParameters()
 
 	if( ItalcConfiguration().isHighDPIScalingEnabled() )
 	{
+
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 6, 0))
 		QApplication::setAttribute( Qt::AA_EnableHighDpiScaling );
+#endif
 	}
 }
 


### PR DESCRIPTION
Hello Tobias,

I'm compiling italc3 on LinuxMint 18 KDE  (QT 5.5.1). 
I edited INSTALL file to include cmake as requirement to compiling. And I disabled HighDpiScaling when QT < 5.6, otherwise it doesn't compile.

Greetings.

PS: **Qt::AA_EnableHighDpiScaling is available only for QT >= 5.6.**