### PR TITLE
Prevent segfaults if VNC connection is null pointer when sending messages

### DIFF
--- a/lib/src/ItalcCoreConnection.cpp
+++ b/lib/src/ItalcCoreConnection.cpp
@@ -73,9 +73,11 @@ ItalcCoreConnection::ItalcCoreConnection( ItalcVncConnection *vncConn ):
 		rfbClientRegisterExtension( __italcProtocolExt );
 	}
 
-	connect( m_vncConn, SIGNAL( newClient( rfbClient * ) ),
-			this, SLOT( initNewClient( rfbClient * ) ),
-							Qt::DirectConnection );
+	if (m_vncConn) {
+		connect( m_vncConn, SIGNAL( newClient( rfbClient * ) ),
+				this, SLOT( initNewClient( rfbClient * ) ),
+				Qt::DirectConnection );
+	}
 }
 
 
@@ -351,6 +353,11 @@ void ItalcCoreConnection::reportSlaveStateFlags()
 void ItalcCoreConnection::enqueueMessage( const ItalcCore::Msg &msg )
 {
 	ItalcCore::Msg m( msg );
+	if (!m_vncConn)
+	{
+		ilog(Error, "ItalcCoreConnection: cannot call enqueueEvent - m_vncConn is NULL");
+		return;
+	}
 	m_vncConn->enqueueEvent( new ItalcMessageEvent( m ) );
 }
 


### PR DESCRIPTION
Prevent segfaults if the VNC connection has never been established.
An example to trigger the segfault with our python bindings is:
```
# python -c 'import italc; c = italc.ItalcCoreConnection(None); c.reportSlaveStateFlags()'
QObject::connect: Cannot connect (null)::newClient( rfbClient * ) to ItalcCoreConnection::initNewClient( rfbClient * )
Segmentation fault
```

Backtrace:
```
> 0  0x00007fe3e55d3f6b in raise () from
/lib/x86_64-linux-gnu/libpthread.so.0
> 1  <signal handler called>
> 2  lockInline (this=0x50) at /usr/include/qt4/QtCore/qmutex.h:187
> 3  QMutexLocker (m=0x50, this=<synthetic pointer>) at
/usr/include/qt4/QtCore/qmutex.h:109
> 4  ItalcVncConnection::enqueueEvent (this=0x0, e=0x7fe37c08d5b0) at
/var/build/temp/tmp.sGv0k6SHwb/pbuilder/italc-2.0.25/lib/src/ItalcVncConnection.cpp:711
> 5  0x00007fe3bf459f24 in ItalcCoreConnection::enqueueMessage
(this=0x7fe37c17fbf0, msg=...) at
/var/build/temp/tmp.sGv0k6SHwb/pbuilder/italc-2.0.25/lib/src/ItalcCoreConnection.cpp:354
> 6  0x00007fe3bf459fec in ItalcCoreConnection::reportSlaveStateFlags
(this=<optimized out>) at
/var/build/temp/tmp.sGv0k6SHwb/pbuilder/italc-2.0.25/lib/src/ItalcCoreConnection.cpp:346
```