### PR TITLE
ItalcVncConnection: Copy image in case the underlying frame buffer ge…

### DIFF
--- a/lib/src/ItalcVncConnection.cpp
+++ b/lib/src/ItalcVncConnection.cpp
@@ -485,7 +485,7 @@ const QImage ItalcVncConnection::image( int x, int y, int w, int h ) const
 
 	if( w == 0 || h == 0 ) // full image requested
 	{
-		return m_image;
+		return m_image.copy(m_image.rect());
 	}
 	return m_image.copy( x, y, w, h );
 }


### PR DESCRIPTION
…ts removed

Removing the framebuffer of QImage instances result in segfaults, e.g.
when using the following python example with our own bindings:
```
import time
import italc
from PyQt4.QtGui import QImageWriter
vnc = italc.ItalcVncConnection()
vnc.setHost('10.200.27.123')
vnc.setPort(11100)
vnc.setQuality(italc.ItalcVncConnection.ThumbnailQuality)
vnc.setFramebufferUpdateInterval(1000)
vnc.start()
time.sleep(1)
image = vnc.image()
time.sleep(15)  # change screen resolution here
image.save("/tmp/foo.jpg", "JPG")
```
This results in the following segfault when the client changes it's screen resolution:
> 0  write_jpeg_image (image=..., device=0xdf7cb0, sourceQuality=-1) at ../../../gui/image/qjpeghandler.cpp:660
> 1  0x00007ffff5698472 in QImageWriter::write (this=0x7fffffffd880, image=...) at image/qimagewriter.cpp:606
> 2  0x00007ffff5686726 in QImage::save (this=0xd9b2d0, fileName=..., format=0x7ffff7eeef2c "JPG", quality=-1) at image/qimage.cpp:5209