### PR TITLE
[italc3] Update CrossCompileForWindows documentation

### DIFF
--- a/doc/CrossCompilingForWindows.txt
+++ b/doc/CrossCompilingForWindows.txt
@@ -23,6 +23,7 @@ Cross compiling iTALC for Windows on Linux
   * libz-mingw-w64-dev
   * libpng-mingw-w64
   * openssl-mingw-w64
+  * interception-mingw-w64
   * default-jdk
 
 - Change into the iTALC source directory and type

--- a/doc/CrossCompilingForWindows.txt
+++ b/doc/CrossCompilingForWindows.txt
@@ -21,7 +21,6 @@ Cross compiling iTALC for Windows on Linux
   * qt5base-mingw-w64
   * qt5tools-mingw-w64
   * libz-mingw-w64-dev
-  * libjpeg-mingw-w64
   * libpng-mingw-w64
   * openssl-mingw-w64
   * default-jdk


### PR DESCRIPTION
Minor corrections on packages dependencies list. 

_libjpeg-mingw-w64_ & _libjpeg-turbo-mingw-w64_ are conflicting into my machine and should be handled by the package provider. 