### PR TITLE
QtSlaveLauncher: fix build for Qt < 5.7.0 (#92)

### DIFF
--- a/lib/src/Ipc/QtSlaveLauncher.cpp
+++ b/lib/src/Ipc/QtSlaveLauncher.cpp
@@ -65,7 +65,7 @@ void QtSlaveLauncher::start( const QStringList &arguments )
 	// forward stdout/stderr from slave to master
 	m_process->setProcessChannelMode( QProcess::ForwardedChannels );
 
-#if QT_VERSION >= 0x050300
+#if QT_VERSION >= 0x050700
 	QObject::connect( m_process, static_cast<void(QProcess::*)(int, QProcess::ExitStatus)>(&QProcess::finished),
 					  m_process, &QProcess::deleteLater );
 	QObject::connect( m_process, static_cast<void(QProcess::*)(int, QProcess::ExitStatus)>(&QProcess::finished),


### PR DESCRIPTION
This patch fixes builds for Qt 5.6.x and lower, making it suitable for some LTS Linux distros (Ubuntu 14.04, openSUSE Leap 42.1 & 42.2, etc.). Closes #92.